### PR TITLE
Adding FocusCount and FocusMilliseconds to UserAssist plugin

### DIFF
--- a/RegistryPlugin.UserAssist/UserAssist.cs
+++ b/RegistryPlugin.UserAssist/UserAssist.cs
@@ -74,7 +74,7 @@ namespace RegistryPlugin.UserAssist
 
                     DateTimeOffset? lastRun = null;
                     int? focusCount = null;
-                    int? focusMilliseconds = null;
+                    TimeSpan focusTime = new TimeSpan();
 
                     if (keyValue.ValueDataRaw.Length >= 16)
                     {
@@ -86,7 +86,7 @@ namespace RegistryPlugin.UserAssist
                         if (keyValue.ValueDataRaw.Length >= 68)
                         {
                             focusCount = BitConverter.ToInt32(keyValue.ValueDataRaw, 8);
-                            focusMilliseconds = BitConverter.ToInt32(keyValue.ValueDataRaw, 12);
+                            focusTime = TimeSpan.FromMilliseconds(BitConverter.ToInt32(keyValue.ValueDataRaw, 12));
                             lastRun = DateTimeOffset.FromFileTime(BitConverter.ToInt64(keyValue.ValueDataRaw, 60));
                         }
                     }
@@ -96,7 +96,7 @@ namespace RegistryPlugin.UserAssist
                         lastRun = null;
                     }
 
-                    var vo = new ValuesOut(keyValue.ValueName, unrot, run, lastRun, focusCount, focusMilliseconds);
+                    var vo = new ValuesOut(keyValue.ValueName, unrot, run, lastRun, focusCount, focusTime.ToString(@"d'd, 'h'h, 'mm'm, 'ss's'"));
 
                     _values.Add(vo);
                 }

--- a/RegistryPlugin.UserAssist/UserAssist.cs
+++ b/RegistryPlugin.UserAssist/UserAssist.cs
@@ -38,7 +38,7 @@ namespace RegistryPlugin.UserAssist
 
         public string LongDescription
             =>
-                "UserAssist is a method used to populate a user’s start menu with frequently used applications. This is achieved by maintaining a count of application use in each users NTUSER.DAT registry file. This key is suppose to contain information about programs and shortcuts accessed by the Windows GUI, including execution count and the date of last execution";
+                "UserAssist is a method used to populate a user’s start menu with frequently used applications. This is achieved by maintaining a count of application use in each users NTUSER.DAT registry file. This key is suppose to contain information about programs and shortcuts accessed by the Windows GUI, including execution count, date of last execution, count of focuses, and total seconds focused";
 
         public double Version => 0.5;
         public List<string> Errors { get; }
@@ -73,6 +73,8 @@ namespace RegistryPlugin.UserAssist
 
 
                     DateTimeOffset? lastRun = null;
+                    int? focusCount = null;
+                    int? focusMilliseconds = null;
 
                     if (keyValue.ValueDataRaw.Length >= 16)
                     {
@@ -80,8 +82,11 @@ namespace RegistryPlugin.UserAssist
 
                         lastRun = DateTimeOffset.FromFileTime(BitConverter.ToInt64(keyValue.ValueDataRaw, 8));
 
+                        // Windows 7 and up, new format
                         if (keyValue.ValueDataRaw.Length >= 68)
                         {
+                            focusCount = BitConverter.ToInt32(keyValue.ValueDataRaw, 8);
+                            focusMilliseconds = BitConverter.ToInt32(keyValue.ValueDataRaw, 12);
                             lastRun = DateTimeOffset.FromFileTime(BitConverter.ToInt64(keyValue.ValueDataRaw, 60));
                         }
                     }
@@ -91,7 +96,7 @@ namespace RegistryPlugin.UserAssist
                         lastRun = null;
                     }
 
-                    var vo = new ValuesOut(keyValue.ValueName, unrot, run, lastRun);
+                    var vo = new ValuesOut(keyValue.ValueName, unrot, run, lastRun, focusCount, focusMilliseconds);
 
                     _values.Add(vo);
                 }

--- a/RegistryPlugin.UserAssist/ValuesOut.cs
+++ b/RegistryPlugin.UserAssist/ValuesOut.cs
@@ -4,21 +4,21 @@ namespace RegistryPlugin.UserAssist
 {
     public class ValuesOut
     {
-        public ValuesOut(string valueName, string programName, int runCounter, DateTimeOffset? lastRun, int? focusCount, int? focusMilliseconds)
+        public ValuesOut(string valueName, string programName, int runCounter, DateTimeOffset? lastRun, int? focusCount, string focusTime)
         {
             ValueName = valueName;
             ProgramName = programName;
             RunCounter = runCounter;
             LastExecuted = lastRun?.UtcDateTime;
             FocusCount = focusCount;
-            FocusMilliseconds = focusMilliseconds;
+            FocusTime = focusTime;
         }
 
         public string ValueName { get; }
         public string ProgramName { get; }
         public int RunCounter { get; }
         public int? FocusCount { get; }
-        public int? FocusMilliseconds { get; }
+        public string FocusTime{ get; }
         public DateTime? LastExecuted { get; }
     }
 }

--- a/RegistryPlugin.UserAssist/ValuesOut.cs
+++ b/RegistryPlugin.UserAssist/ValuesOut.cs
@@ -4,17 +4,21 @@ namespace RegistryPlugin.UserAssist
 {
     public class ValuesOut
     {
-        public ValuesOut(string valueName, string programName, int runCounter, DateTimeOffset? lastRun)
+        public ValuesOut(string valueName, string programName, int runCounter, DateTimeOffset? lastRun, int? focusCount, int? focusMilliseconds)
         {
             ValueName = valueName;
             ProgramName = programName;
             RunCounter = runCounter;
             LastExecuted = lastRun?.UtcDateTime;
+            FocusCount = focusCount;
+            FocusMilliseconds = focusMilliseconds;
         }
 
         public string ValueName { get; }
         public string ProgramName { get; }
         public int RunCounter { get; }
+        public int? FocusCount { get; }
+        public int? FocusMilliseconds { get; }
         public DateTime? LastExecuted { get; }
     }
 }

--- a/RegistryPlugins.Test/PluginTests.cs
+++ b/RegistryPlugins.Test/PluginTests.cs
@@ -22,6 +22,7 @@ using RegistryPlugin.Services;
 using RegistryPlugin.TerminalServerClient;
 using RegistryPlugin.TypedURLs;
 using RegistryPlugin.WordWheelQuery;
+using RegistryPlugin.UserAssist;
 using ValuesOut = RegistryPlugin.AppCompatCache.ValuesOut;
 
 namespace RegistryPlugins.Test
@@ -246,6 +247,33 @@ namespace RegistryPlugins.Test
 
             Check.That(ff.MruPosition).IsEqualTo(1);
             Check.That(ff.SearchTerm).Contains("jboone");
+        }
+
+        [Test]
+        public void BlakeUserAssist()
+        {
+            var r = new UserAssist();
+
+            var reg = new RegistryHive(@"D:\Sync\RegistryHives\NTUSER_dblake.DAT");
+            reg.ParseHive();
+
+            var key = reg.GetKey(@"Software\Microsoft\Windows\CurrentVersion\Explorer\UserAssist\{CEBFF5CD-ACE2-4F4F-9178-9926F41749EA}\Count");
+
+            Check.That(r.Values.Count).IsEqualTo(0);
+
+            r.ProcessValues(key);
+
+            Check.That(r.Values.Count).IsEqualTo(205);
+            Check.That(r.Errors.Count).IsEqualTo(0);
+
+            var ff = (RegistryPlugin.UserAssist.ValuesOut)r.Values[1];
+
+            Check.That(ff.RunCounter).IsEqualTo(0);
+            Check.That(ff.ProgramName).IsEqualTo("Microsoft.Windows.Explorer");
+            Check.That(ff.FocusCount).IsEqualTo(619);
+            Check.That(ff.FocusMilliseconds).IsEqualTo(13584008);
+
+
         }
 
         [Test]

--- a/RegistryPlugins.Test/PluginTests.cs
+++ b/RegistryPlugins.Test/PluginTests.cs
@@ -271,7 +271,7 @@ namespace RegistryPlugins.Test
             Check.That(ff.RunCounter).IsEqualTo(0);
             Check.That(ff.ProgramName).IsEqualTo("Microsoft.Windows.Explorer");
             Check.That(ff.FocusCount).IsEqualTo(619);
-            Check.That(ff.FocusMilliseconds).IsEqualTo(13584008);
+            Check.That(ff.FocusTime).IsEqualTo("0d, 3h, 46m, 24s");
 
 
         }


### PR DESCRIPTION
- Adds FocusCount and FocusMilliseconds to the UserAssist.ValuesOut type, and parses those values out if the byte layout is in the Win7+ format.
- Adds tests for UserAssist

Credit for figuring out the format information goes to Didier Stevens: https://blog.didierstevens.com/2010/01/04/new-format-for-userassist-registry-keys/