### PR TITLE
Experimental account flags parsing for SAM plugin

### DIFF
--- a/RegistryPlugin.SAM/UserAccounts.cs
+++ b/RegistryPlugin.SAM/UserAccounts.cs
@@ -169,17 +169,17 @@ namespace RegistryPlugin.SAM
                         {
                             lastIncorrectPwTime = tempTime.ToUniversalTime();
                         }
+                        
+                        var parsedAccountFlags = (AccountFlags)BitConverter.ToInt16(vVal.ValueDataRaw, 0x56);
+                        // I would just return the parsed/cast AccountFlags enum object then you can do comparisons
+                        // to check each for display using the Enum.HasFlag method like so:
+                        // bool accountDisabled = parsedAccountFlags.HasFlag(AccountFlags.AccountDisabled)
                     }
 
                     var vVal = key1.Values.SingleOrDefault(t => t.ValueName == "V");
 
                     if (vVal != null)
                     {
-                        var parsedAccountFlags = (AccountFlags)BitConverter.ToInt16(vVal.ValueDataRaw, 0xAC);
-                        // I would just return the parsed/cast AccountFlags enum object then you can do comparisons
-                        // to check each for display using the Enum.HasFlag method like so:
-                        // bool accountDisabled = parsedAccountFlags.HasFlag(AccountFlags.AccountDisabled)
-                        
                         var offToName = BitConverter.ToInt32(vVal.ValueDataRaw, 0xc) + 0xCC;
                         var nameLen = BitConverter.ToInt32(vVal.ValueDataRaw, 0xc + 4);
                         var name1 = Encoding.Unicode.GetString(vVal.ValueDataRaw, offToName, nameLen);

--- a/RegistryPlugin.SAM/UserAccounts.cs
+++ b/RegistryPlugin.SAM/UserAccounts.cs
@@ -143,6 +143,12 @@ namespace RegistryPlugin.SAM
 
                     if (vVal != null)
                     {
+                        // see https://windowsir.blogspot.com/2009/07/user-account-analysis.html
+                        bool passwordPolicyRequired = false;
+                        var passwordRequiredByte = BitConverter.ToInt32(vVal.ValueDataRaw, 0xAC);
+                        if(passwordRequiredByte == 0x14)
+                            passwordPolicyRequired = true;
+                        
                         var offToName = BitConverter.ToInt32(vVal.ValueDataRaw, 0xc) + 0xCC;
                         var nameLen = BitConverter.ToInt32(vVal.ValueDataRaw, 0xc + 4);
                         var name1 = Encoding.Unicode.GetString(vVal.ValueDataRaw, offToName, nameLen);
@@ -180,7 +186,7 @@ namespace RegistryPlugin.SAM
 
                         var u = new UserOut(userId, invalidLogins, totalLogins, lastLoginTime, lastPwChangeTime,
                             lastIncorrectPwTime, acctExpiresTime, name1, full1, comment, userComment, homeDir,
-                            createdOn, groups, hint);
+                            createdOn, groups, hint, passwordPolicyRequired);
 
                         _values.Add(u);
                     }

--- a/RegistryPlugin.SAM/UserAccounts.cs
+++ b/RegistryPlugin.SAM/UserAccounts.cs
@@ -9,6 +9,39 @@ using RegistryPluginBase.Interfaces;
 
 namespace RegistryPlugin.SAM
 {
+    // see https://github.com/keydet89/RegRipper2.8/blob/master/plugins/samparse.pl#L52
+    // see also https://windowsir.blogspot.com/2009/07/user-account-analysis.html
+    ///<summary>Account flags</summary>
+    // NOT TESTED -- make sure this is right place to declare this
+    [Flags]
+    public enum AccountFlags
+    {
+        ///<summary>Default value (no flags)</summary>
+        None            = 0x0000,
+        ///<summary>Account is disabled</summary>
+        AccountDisabled     = 0x0001,
+        ///<summary>The home directory is required.</summary>
+        HomeDirectoryRequired   = 0x0002,
+        ///<summary>No password is required.</summary>
+        PasswordNotRequired     = 0x0004,
+        ///<summary>This is an account for users whose primary account is in another domain. This account provides user access to this domain, but not to any domain that trusts this domain. Also known as a local user account.</summary>
+        TempDuplicateAccount    = 0x0008,
+        ///<summary>This is a default account type that represents a typical user.</summary>
+        NormalUserAccount       = 0x0010,
+        ///<summary>This is an Majority Node Set (MNS) logon account. With MNS, you can configure a multi-node Windows cluster without using a common shared disk.</summary>
+        MnsLogonAccount     = 0x0020,
+        ///<summary>This is a permit to trust account for a system domain that trusts other domains.</summary>
+        InterdomainTrustAccount = 0x0040,
+        ///<summary>This is a computer account for a Windows or Windows Server that is a member of this domain.</summary>
+        WorkstationTrustAccount = 0x0080,
+        ///<summary>This is a computer account for a system backup domain controller that is a member of this domain.</summary>
+        ServerTrustAccount      = 0x0100,
+        ///<summary>The password will not expire on this account.</summary>
+        PasswordDoesNotExpire   = 0x0200,
+        ///<summary>Account auto locked (I'm not entirely sure what this means)</summary>
+        AutoLocked          = 0x0400
+    }
+
     public class UserAccounts : IRegistryPluginGrid
     {
         private readonly BindingList<UserOut> _values;
@@ -21,7 +54,6 @@ namespace RegistryPlugin.SAM
 
             Groups = new List<GroupInfo>();
         }
-
 
         private List<GroupInfo> Groups { get; }
 
@@ -143,39 +175,6 @@ namespace RegistryPlugin.SAM
 
                     if (vVal != null)
                     {
-                        // see https://github.com/keydet89/RegRipper2.8/blob/master/plugins/samparse.pl#L52
-                        // see also https://windowsir.blogspot.com/2009/07/user-account-analysis.html
-                        ///<summary>Account flags</summary>
-                        // this should probably be declared elsewhere but here it is for now
-                        [Flags]
-                        public enum AccountFlags
-                        {
-                            ///<summary>Default value (no flags)</summary>
-                            None                    = 0x0000,
-                            ///<summary>Account is disabled</summary>
-                            AccountDisabled         = 0x0001,
-                            ///<summary>The home directory is required.</summary>
-                            HomeDirectoryRequired   = 0x0002,
-                            ///<summary>No password is required.</summary>
-                            PasswordNotRequired     = 0x0004,
-                            ///<summary>This is an account for users whose primary account is in another domain. This account provides user access to this domain, but not to any domain that trusts this domain. Also known as a local user account.</summary>
-                            TempDuplicateAccount    = 0x0008,
-                            ///<summary>This is a default account type that represents a typical user.</summary>
-                            NormalUserAccount       = 0x0010,
-                            ///<summary>This is an Majority Node Set (MNS) logon account. With MNS, you can configure a multi-node Windows cluster without using a common shared disk.</summary>
-                            MnsLogonAccount         = 0x0020,
-                            ///<summary>This is a permit to trust account for a system domain that trusts other domains.</summary>
-                            InterdomainTrustAccount = 0x0040,
-                            ///<summary>This is a computer account for a Windows or Windows Server that is a member of this domain.</summary>
-                            WorkstationTrustAccount = 0x0080,
-                            ///<summary>This is a computer account for a system backup domain controller that is a member of this domain.</summary>
-                            ServerTrustAccount      = 0x0100,
-                            ///<summary>The password will not expire on this account.</summary>
-                            PasswordDoesNotExpire   = 0x0200,
-                            ///<summary>Account auto locked (I'm not entirely sure what this means)</summary>
-                            AutoLocked              = 0x0400
-                        }
-                        
                         var parsedAccountFlags = (AccountFlags)BitConverter.ToInt16(vVal.ValueDataRaw, 0xAC);
                         // I would just return the parsed/cast AccountFlags enum object then you can do comparisons
                         // to check each for display using the Enum.HasFlag method like so:

--- a/RegistryPlugin.SAM/UserAccounts.cs
+++ b/RegistryPlugin.SAM/UserAccounts.cs
@@ -170,7 +170,7 @@ namespace RegistryPlugin.SAM
                             lastIncorrectPwTime = tempTime.ToUniversalTime();
                         }
                         
-                        var parsedAccountFlags = (AccountFlags)BitConverter.ToInt16(vVal.ValueDataRaw, 0x56);
+                        var parsedAccountFlags = (AccountFlags)BitConverter.ToInt16(fVal.ValueDataRaw, 0x56);
                         // I would just return the parsed/cast AccountFlags enum object then you can do comparisons
                         // to check each for display using the Enum.HasFlag method like so:
                         // bool accountDisabled = parsedAccountFlags.HasFlag(AccountFlags.AccountDisabled)

--- a/RegistryPlugin.SAM/UserAccounts.cs
+++ b/RegistryPlugin.SAM/UserAccounts.cs
@@ -143,11 +143,43 @@ namespace RegistryPlugin.SAM
 
                     if (vVal != null)
                     {
-                        // see https://windowsir.blogspot.com/2009/07/user-account-analysis.html
-                        bool passwordPolicyRequired = false;
-                        var passwordRequiredByte = BitConverter.ToInt32(vVal.ValueDataRaw, 0xAC);
-                        if(passwordRequiredByte == 0x14)
-                            passwordPolicyRequired = true;
+                        // see https://github.com/keydet89/RegRipper2.8/blob/master/plugins/samparse.pl#L52
+                        // see also https://windowsir.blogspot.com/2009/07/user-account-analysis.html
+                        ///<summary>Account flags</summary>
+                        // this should probably be declared elsewhere but here it is for now
+                        [Flags]
+                        public enum AccountFlags
+                        {
+                            ///<summary>Default value (no flags)</summary>
+                            None                    = 0x0000,
+                            ///<summary>Account is disabled</summary>
+                            AccountDisabled         = 0x0001,
+                            ///<summary>The home directory is required.</summary>
+                            HomeDirectoryRequired   = 0x0002,
+                            ///<summary>No password is required.</summary>
+                            PasswordNotRequired     = 0x0004,
+                            ///<summary>This is an account for users whose primary account is in another domain. This account provides user access to this domain, but not to any domain that trusts this domain. Also known as a local user account.</summary>
+                            TempDuplicateAccount    = 0x0008,
+                            ///<summary>This is a default account type that represents a typical user.</summary>
+                            NormalUserAccount       = 0x0010,
+                            ///<summary>This is an Majority Node Set (MNS) logon account. With MNS, you can configure a multi-node Windows cluster without using a common shared disk.</summary>
+                            MnsLogonAccount         = 0x0020,
+                            ///<summary>This is a permit to trust account for a system domain that trusts other domains.</summary>
+                            InterdomainTrustAccount = 0x0040,
+                            ///<summary>This is a computer account for a Windows or Windows Server that is a member of this domain.</summary>
+                            WorkstationTrustAccount = 0x0080,
+                            ///<summary>This is a computer account for a system backup domain controller that is a member of this domain.</summary>
+                            ServerTrustAccount      = 0x0100,
+                            ///<summary>The password will not expire on this account.</summary>
+                            PasswordDoesNotExpire   = 0x0200,
+                            ///<summary>Account auto locked (I'm not entirely sure what this means)</summary>
+                            AutoLocked              = 0x0400
+                        }
+                        
+                        var parsedAccountFlags = (AccountFlags)BitConverter.ToInt16(vVal.ValueDataRaw, 0xAC);
+                        // I would just return the parsed/cast AccountFlags enum object then you can do comparisons
+                        // to check each for display using the Enum.HasFlag method like so:
+                        // bool accountDisabled = parsedAccountFlags.HasFlag(AccountFlags.AccountDisabled)
                         
                         var offToName = BitConverter.ToInt32(vVal.ValueDataRaw, 0xc) + 0xCC;
                         var nameLen = BitConverter.ToInt32(vVal.ValueDataRaw, 0xc + 4);
@@ -186,7 +218,7 @@ namespace RegistryPlugin.SAM
 
                         var u = new UserOut(userId, invalidLogins, totalLogins, lastLoginTime, lastPwChangeTime,
                             lastIncorrectPwTime, acctExpiresTime, name1, full1, comment, userComment, homeDir,
-                            createdOn, groups, hint, passwordPolicyRequired);
+                            createdOn, groups, hint, parsedAccountFlags);
 
                         _values.Add(u);
                     }

--- a/RegistryPlugin.SAM/UserOut.cs
+++ b/RegistryPlugin.SAM/UserOut.cs
@@ -8,7 +8,7 @@ namespace RegistryPlugin.SAM
             DateTimeOffset? lastPwChange, DateTimeOffset? lastIncorrectLogin, DateTimeOffset? expiresOn,
             string username,
             string fullName, string comment, string userComment, string homeDir, DateTimeOffset createdOn,
-            string groups, string pwHint, bool passwordPolicyRequired)
+            string groups, string pwHint, AccountFlags parsedAccountFlags)
         {
             UserId = userId;
             InvalidLoginCount = invalidLoginCount;
@@ -25,7 +25,7 @@ namespace RegistryPlugin.SAM
             CreatedOn = createdOn.UtcDateTime;
             Groups = groups;
             PasswordHint = pwHint;
-            PasswordPolicyRequired = passwordPolicyRequired;
+            AccountFlagsEnum = parsedAccountFlags;
         }
 
         public int UserId { get; }
@@ -51,6 +51,13 @@ namespace RegistryPlugin.SAM
         public string Comment { get; }
         public string UserComment { get; }
         public string HomeDirectory { get; }
-        public bool PasswordPolicyRequired { get; }
+        public bool AccountDisabled { 
+            get {
+                return AccountFlagsEnum.HasFlag(AccountFlags.AccountDisabled);
+            }
+            private set;  // correct if this is not good C# syntax
+        }
+        // and so on using the Enum.HasFlag method for each AccountFlags flag
+        // before I type this all out I just want to see if this approach even works
     }
 }

--- a/RegistryPlugin.SAM/UserOut.cs
+++ b/RegistryPlugin.SAM/UserOut.cs
@@ -8,7 +8,7 @@ namespace RegistryPlugin.SAM
             DateTimeOffset? lastPwChange, DateTimeOffset? lastIncorrectLogin, DateTimeOffset? expiresOn,
             string username,
             string fullName, string comment, string userComment, string homeDir, DateTimeOffset createdOn,
-            string groups, string pwHint)
+            string groups, string pwHint, bool passwordPolicyRequired)
         {
             UserId = userId;
             InvalidLoginCount = invalidLoginCount;
@@ -25,6 +25,7 @@ namespace RegistryPlugin.SAM
             CreatedOn = createdOn.UtcDateTime;
             Groups = groups;
             PasswordHint = pwHint;
+            PasswordPolicyRequired = passwordPolicyRequired;
         }
 
         public int UserId { get; }
@@ -50,5 +51,6 @@ namespace RegistryPlugin.SAM
         public string Comment { get; }
         public string UserComment { get; }
         public string HomeDirectory { get; }
+        public bool PasswordPolicyRequired { get; }
     }
 }


### PR DESCRIPTION
Untested (not sure I could build if I wanted to without DevExpress, etc.) attempt at parsing account flags. I didn't type out all the properties that would be needed to do it this way (I also commented on an alternate way if you wanted to extract all bool values before passing out values).

My last (closed) pull request was reading from the wrong byte offset. This should be correct but needs testing (see https://github.com/keydet89/RegRipper2.8/blob/master/plugins/samparse.pl#L238).

Apologies for closing multiple previous pull requests. I am doing all these edits inside my browser in the GitHub editor (no IDE) so made some minor/dumb mistakes. This should be right now but please verify if it works using this approach. Thanks