### PR TITLE
Parse additional SAM account flags

### DIFF
--- a/RegistryPlugin.SAM/UserAccounts.cs
+++ b/RegistryPlugin.SAM/UserAccounts.cs
@@ -169,17 +169,17 @@ namespace RegistryPlugin.SAM
                         {
                             lastIncorrectPwTime = tempTime.ToUniversalTime();
                         }
+                        
+                        var parsedAccountFlags = (AccountFlags)BitConverter.ToInt16(vVal.ValueDataRaw, 0x56);
+                        // I would just return the parsed/cast AccountFlags enum object then you can do comparisons
+                        // to check each for display using the Enum.HasFlag method like so:
+                        // bool accountDisabled = parsedAccountFlags.HasFlag(AccountFlags.AccountDisabled)
                     }
 
                     var vVal = key1.Values.SingleOrDefault(t => t.ValueName == "V");
 
                     if (vVal != null)
                     {
-                        var parsedAccountFlags = (AccountFlags)BitConverter.ToInt16(vVal.ValueDataRaw, 0xAC);
-                        // I would just return the parsed/cast AccountFlags enum object then you can do comparisons
-                        // to check each for display using the Enum.HasFlag method like so:
-                        // bool accountDisabled = parsedAccountFlags.HasFlag(AccountFlags.AccountDisabled)
-                        
                         var offToName = BitConverter.ToInt32(vVal.ValueDataRaw, 0xc) + 0xCC;
                         var nameLen = BitConverter.ToInt32(vVal.ValueDataRaw, 0xc + 4);
                         var name1 = Encoding.Unicode.GetString(vVal.ValueDataRaw, offToName, nameLen);

--- a/RegistryPlugin.SAM/UserAccounts.cs
+++ b/RegistryPlugin.SAM/UserAccounts.cs
@@ -9,17 +9,15 @@ using RegistryPluginBase.Interfaces;
 
 namespace RegistryPlugin.SAM
 {
-    // see https://github.com/keydet89/RegRipper2.8/blob/master/plugins/samparse.pl#L52
     // see also https://windowsir.blogspot.com/2009/07/user-account-analysis.html
-    ///<summary>Account flags</summary>
-    // NOT TESTED -- make sure this is right place to declare this
+    ///<summary>SAM Account flags</summary>
     [Flags]
     public enum AccountFlags
     {
         ///<summary>Default value (no flags)</summary>
-        None            = 0x0000,
+        None                    = 0x0000,
         ///<summary>Account is disabled</summary>
-        AccountDisabled     = 0x0001,
+        AccountDisabled         = 0x0001,
         ///<summary>The home directory is required.</summary>
         HomeDirectoryRequired   = 0x0002,
         ///<summary>No password is required.</summary>
@@ -29,7 +27,7 @@ namespace RegistryPlugin.SAM
         ///<summary>This is a default account type that represents a typical user.</summary>
         NormalUserAccount       = 0x0010,
         ///<summary>This is an Majority Node Set (MNS) logon account. With MNS, you can configure a multi-node Windows cluster without using a common shared disk.</summary>
-        MnsLogonAccount     = 0x0020,
+        MnsLogonAccount         = 0x0020,
         ///<summary>This is a permit to trust account for a system domain that trusts other domains.</summary>
         InterdomainTrustAccount = 0x0040,
         ///<summary>This is a computer account for a Windows or Windows Server that is a member of this domain.</summary>
@@ -39,7 +37,7 @@ namespace RegistryPlugin.SAM
         ///<summary>The password will not expire on this account.</summary>
         PasswordDoesNotExpire   = 0x0200,
         ///<summary>Account auto locked (I'm not entirely sure what this means)</summary>
-        AutoLocked          = 0x0400
+        AutoLocked              = 0x0400
     }
 
     public class UserAccounts : IRegistryPluginGrid
@@ -130,6 +128,7 @@ namespace RegistryPlugin.SAM
                     DateTimeOffset? lastPwChangeTime = null;
                     DateTimeOffset? acctExpiresTime = null;
                     DateTimeOffset? lastIncorrectPwTime = null;
+                    var parsedAccountFlags = AccountFlags.None;
 
                     if (fVal != null)
                     {
@@ -169,11 +168,9 @@ namespace RegistryPlugin.SAM
                         {
                             lastIncorrectPwTime = tempTime.ToUniversalTime();
                         }
-                        
-                        var parsedAccountFlags = (AccountFlags)BitConverter.ToInt16(fVal.ValueDataRaw, 0x56);
-                        // I would just return the parsed/cast AccountFlags enum object then you can do comparisons
-                        // to check each for display using the Enum.HasFlag method like so:
-                        // bool accountDisabled = parsedAccountFlags.HasFlag(AccountFlags.AccountDisabled)
+
+                        // see https://github.com/keydet89/RegRipper2.8/blob/master/plugins/samparse.pl#L52
+                        parsedAccountFlags = (AccountFlags)BitConverter.ToInt16(fVal.ValueDataRaw, 0x56);
                     }
 
                     var vVal = key1.Values.SingleOrDefault(t => t.ValueName == "V");

--- a/RegistryPlugin.SAM/UserAccounts.cs
+++ b/RegistryPlugin.SAM/UserAccounts.cs
@@ -143,6 +143,12 @@ namespace RegistryPlugin.SAM
 
                     if (vVal != null)
                     {
+                        // see https://windowsir.blogspot.com/2009/07/user-account-analysis.html
+                        bool passwordPolicyRequired = false;
+                        var passwordRequiredByte = BitConverter.ToInt32(vVal.ValueDataRaw, 0xAC);
+                        if(passwordRequiredByte == 0x14)
+                            passwordPolicyRequired = true;
+                        
                         var offToName = BitConverter.ToInt32(vVal.ValueDataRaw, 0xc) + 0xCC;
                         var nameLen = BitConverter.ToInt32(vVal.ValueDataRaw, 0xc + 4);
                         var name1 = Encoding.Unicode.GetString(vVal.ValueDataRaw, offToName, nameLen);
@@ -180,7 +186,7 @@ namespace RegistryPlugin.SAM
 
                         var u = new UserOut(userId, invalidLogins, totalLogins, lastLoginTime, lastPwChangeTime,
                             lastIncorrectPwTime, acctExpiresTime, name1, full1, comment, userComment, homeDir,
-                            createdOn, groups, hint);
+                            createdOn, groups, hint, passwordPolicyRequired);
 
                         _values.Add(u);
                     }

--- a/RegistryPlugin.SAM/UserAccounts.cs
+++ b/RegistryPlugin.SAM/UserAccounts.cs
@@ -9,7 +9,6 @@ using RegistryPluginBase.Interfaces;
 
 namespace RegistryPlugin.SAM
 {
-    // see also https://windowsir.blogspot.com/2009/07/user-account-analysis.html
     ///<summary>SAM Account flags</summary>
     [Flags]
     public enum AccountFlags
@@ -74,8 +73,12 @@ namespace RegistryPlugin.SAM
         public string ShortDescription => "Displays user accounts and user account details";
 
         public string LongDescription
-            =>
-                "http://www.beginningtoseethelight.org/ntsecurity/index.htm has details on SAM layout";
+            => String.Join(
+            Environment.NewLine,
+            "See the following URLs for more",
+            "http://www.beginningtoseethelight.org/ntsecurity/index.htm has details on SAM layout,",
+            "https://windowsir.blogspot.com/2009/07/user-account-analysis.html further explains the 'Password not required' flag,"
+        );
 
         public double Version => 0.5;
         public List<string> Errors { get; }
@@ -169,7 +172,6 @@ namespace RegistryPlugin.SAM
                             lastIncorrectPwTime = tempTime.ToUniversalTime();
                         }
 
-                        // see https://github.com/keydet89/RegRipper2.8/blob/master/plugins/samparse.pl#L52
                         parsedAccountFlags = (AccountFlags)BitConverter.ToInt16(fVal.ValueDataRaw, 0x56);
                     }
 

--- a/RegistryPlugin.SAM/UserAccounts.cs
+++ b/RegistryPlugin.SAM/UserAccounts.cs
@@ -9,6 +9,39 @@ using RegistryPluginBase.Interfaces;
 
 namespace RegistryPlugin.SAM
 {
+    // see https://github.com/keydet89/RegRipper2.8/blob/master/plugins/samparse.pl#L52
+    // see also https://windowsir.blogspot.com/2009/07/user-account-analysis.html
+    ///<summary>Account flags</summary>
+    // NOT TESTED -- make sure this is right place to declare this
+    [Flags]
+    public enum AccountFlags
+    {
+        ///<summary>Default value (no flags)</summary>
+        None            = 0x0000,
+        ///<summary>Account is disabled</summary>
+        AccountDisabled     = 0x0001,
+        ///<summary>The home directory is required.</summary>
+        HomeDirectoryRequired   = 0x0002,
+        ///<summary>No password is required.</summary>
+        PasswordNotRequired     = 0x0004,
+        ///<summary>This is an account for users whose primary account is in another domain. This account provides user access to this domain, but not to any domain that trusts this domain. Also known as a local user account.</summary>
+        TempDuplicateAccount    = 0x0008,
+        ///<summary>This is a default account type that represents a typical user.</summary>
+        NormalUserAccount       = 0x0010,
+        ///<summary>This is an Majority Node Set (MNS) logon account. With MNS, you can configure a multi-node Windows cluster without using a common shared disk.</summary>
+        MnsLogonAccount     = 0x0020,
+        ///<summary>This is a permit to trust account for a system domain that trusts other domains.</summary>
+        InterdomainTrustAccount = 0x0040,
+        ///<summary>This is a computer account for a Windows or Windows Server that is a member of this domain.</summary>
+        WorkstationTrustAccount = 0x0080,
+        ///<summary>This is a computer account for a system backup domain controller that is a member of this domain.</summary>
+        ServerTrustAccount      = 0x0100,
+        ///<summary>The password will not expire on this account.</summary>
+        PasswordDoesNotExpire   = 0x0200,
+        ///<summary>Account auto locked (I'm not entirely sure what this means)</summary>
+        AutoLocked          = 0x0400
+    }
+
     public class UserAccounts : IRegistryPluginGrid
     {
         private readonly BindingList<UserOut> _values;
@@ -21,7 +54,6 @@ namespace RegistryPlugin.SAM
 
             Groups = new List<GroupInfo>();
         }
-
 
         private List<GroupInfo> Groups { get; }
 
@@ -143,39 +175,6 @@ namespace RegistryPlugin.SAM
 
                     if (vVal != null)
                     {
-                        // see https://github.com/keydet89/RegRipper2.8/blob/master/plugins/samparse.pl#L52
-                        // see also https://windowsir.blogspot.com/2009/07/user-account-analysis.html
-                        ///<summary>Account flags</summary>
-                        // this should probably be declared elsewhere but here it is for now
-                        [Flags]
-                        public enum AccountFlags
-                        {
-                            ///<summary>Default value (no flags)</summary>
-                            None                    = 0x0000,
-                            ///<summary>Account is disabled</summary>
-                            AccountDisabled         = 0x0001,
-                            ///<summary>The home directory is required.</summary>
-                            HomeDirectoryRequired   = 0x0002,
-                            ///<summary>No password is required.</summary>
-                            PasswordNotRequired     = 0x0004,
-                            ///<summary>This is an account for users whose primary account is in another domain. This account provides user access to this domain, but not to any domain that trusts this domain. Also known as a local user account.</summary>
-                            TempDuplicateAccount    = 0x0008,
-                            ///<summary>This is a default account type that represents a typical user.</summary>
-                            NormalUserAccount       = 0x0010,
-                            ///<summary>This is an Majority Node Set (MNS) logon account. With MNS, you can configure a multi-node Windows cluster without using a common shared disk.</summary>
-                            MnsLogonAccount         = 0x0020,
-                            ///<summary>This is a permit to trust account for a system domain that trusts other domains.</summary>
-                            InterdomainTrustAccount = 0x0040,
-                            ///<summary>This is a computer account for a Windows or Windows Server that is a member of this domain.</summary>
-                            WorkstationTrustAccount = 0x0080,
-                            ///<summary>This is a computer account for a system backup domain controller that is a member of this domain.</summary>
-                            ServerTrustAccount      = 0x0100,
-                            ///<summary>The password will not expire on this account.</summary>
-                            PasswordDoesNotExpire   = 0x0200,
-                            ///<summary>Account auto locked (I'm not entirely sure what this means)</summary>
-                            AutoLocked              = 0x0400
-                        }
-                        
                         var parsedAccountFlags = (AccountFlags)BitConverter.ToInt16(vVal.ValueDataRaw, 0xAC);
                         // I would just return the parsed/cast AccountFlags enum object then you can do comparisons
                         // to check each for display using the Enum.HasFlag method like so:

--- a/RegistryPlugin.SAM/UserAccounts.cs
+++ b/RegistryPlugin.SAM/UserAccounts.cs
@@ -170,7 +170,7 @@ namespace RegistryPlugin.SAM
                             lastIncorrectPwTime = tempTime.ToUniversalTime();
                         }
                         
-                        var parsedAccountFlags = (AccountFlags)BitConverter.ToInt16(vVal.ValueDataRaw, 0x56);
+                        var parsedAccountFlags = (AccountFlags)BitConverter.ToInt16(fVal.ValueDataRaw, 0x56);
                         // I would just return the parsed/cast AccountFlags enum object then you can do comparisons
                         // to check each for display using the Enum.HasFlag method like so:
                         // bool accountDisabled = parsedAccountFlags.HasFlag(AccountFlags.AccountDisabled)

--- a/RegistryPlugin.SAM/UserAccounts.cs
+++ b/RegistryPlugin.SAM/UserAccounts.cs
@@ -143,11 +143,43 @@ namespace RegistryPlugin.SAM
 
                     if (vVal != null)
                     {
-                        // see https://windowsir.blogspot.com/2009/07/user-account-analysis.html
-                        bool passwordPolicyRequired = false;
-                        var passwordRequiredByte = BitConverter.ToInt32(vVal.ValueDataRaw, 0xAC);
-                        if(passwordRequiredByte == 0x14)
-                            passwordPolicyRequired = true;
+                        // see https://github.com/keydet89/RegRipper2.8/blob/master/plugins/samparse.pl#L52
+                        // see also https://windowsir.blogspot.com/2009/07/user-account-analysis.html
+                        ///<summary>Account flags</summary>
+                        // this should probably be declared elsewhere but here it is for now
+                        [Flags]
+                        public enum AccountFlags
+                        {
+                            ///<summary>Default value (no flags)</summary>
+                            None                    = 0x0000,
+                            ///<summary>Account is disabled</summary>
+                            AccountDisabled         = 0x0001,
+                            ///<summary>The home directory is required.</summary>
+                            HomeDirectoryRequired   = 0x0002,
+                            ///<summary>No password is required.</summary>
+                            PasswordNotRequired     = 0x0004,
+                            ///<summary>This is an account for users whose primary account is in another domain. This account provides user access to this domain, but not to any domain that trusts this domain. Also known as a local user account.</summary>
+                            TempDuplicateAccount    = 0x0008,
+                            ///<summary>This is a default account type that represents a typical user.</summary>
+                            NormalUserAccount       = 0x0010,
+                            ///<summary>This is an Majority Node Set (MNS) logon account. With MNS, you can configure a multi-node Windows cluster without using a common shared disk.</summary>
+                            MnsLogonAccount         = 0x0020,
+                            ///<summary>This is a permit to trust account for a system domain that trusts other domains.</summary>
+                            InterdomainTrustAccount = 0x0040,
+                            ///<summary>This is a computer account for a Windows or Windows Server that is a member of this domain.</summary>
+                            WorkstationTrustAccount = 0x0080,
+                            ///<summary>This is a computer account for a system backup domain controller that is a member of this domain.</summary>
+                            ServerTrustAccount      = 0x0100,
+                            ///<summary>The password will not expire on this account.</summary>
+                            PasswordDoesNotExpire   = 0x0200,
+                            ///<summary>Account auto locked (I'm not entirely sure what this means)</summary>
+                            AutoLocked              = 0x0400
+                        }
+                        
+                        var parsedAccountFlags = (AccountFlags)BitConverter.ToInt16(vVal.ValueDataRaw, 0xAC);
+                        // I would just return the parsed/cast AccountFlags enum object then you can do comparisons
+                        // to check each for display using the Enum.HasFlag method like so:
+                        // bool accountDisabled = parsedAccountFlags.HasFlag(AccountFlags.AccountDisabled)
                         
                         var offToName = BitConverter.ToInt32(vVal.ValueDataRaw, 0xc) + 0xCC;
                         var nameLen = BitConverter.ToInt32(vVal.ValueDataRaw, 0xc + 4);
@@ -186,7 +218,7 @@ namespace RegistryPlugin.SAM
 
                         var u = new UserOut(userId, invalidLogins, totalLogins, lastLoginTime, lastPwChangeTime,
                             lastIncorrectPwTime, acctExpiresTime, name1, full1, comment, userComment, homeDir,
-                            createdOn, groups, hint, passwordPolicyRequired);
+                            createdOn, groups, hint, parsedAccountFlags);
 
                         _values.Add(u);
                     }

--- a/RegistryPlugin.SAM/UserOut.cs
+++ b/RegistryPlugin.SAM/UserOut.cs
@@ -51,13 +51,30 @@ namespace RegistryPlugin.SAM
         public string Comment { get; }
         public string UserComment { get; }
         public string HomeDirectory { get; }
-        public bool AccountDisabled { 
-            get {
-                return AccountFlagsEnum.HasFlag(AccountFlags.AccountDisabled);
-            }
-            private set;  // correct if this is not good C# syntax
+
+        private AccountFlags AccountFlagsEnum { get; }
+        public bool AccountDisabled         => this.HasFlag(AccountFlags.AccountDisabled);
+        public bool HomeDirectoryRequired   => this.HasFlag(AccountFlags.HomeDirectoryRequired);
+        public bool PasswordNotRequired     => this.HasFlag(AccountFlags.PasswordNotRequired);
+        public bool TempDuplicateAccount    => this.HasFlag(AccountFlags.TempDuplicateAccount);
+        public bool NormalUserAccount       => this.HasFlag(AccountFlags.NormalUserAccount);
+        public bool MnsLogonAccount         => this.HasFlag(AccountFlags.MnsLogonAccount);
+        public bool InterdomainTrustAccount => this.HasFlag(AccountFlags.InterdomainTrustAccount);
+        public bool WorkstationTrustAccount => this.HasFlag(AccountFlags.WorkstationTrustAccount);
+        public bool ServerTrustAccount      => this.HasFlag(AccountFlags.ServerTrustAccount);
+        public bool PasswordDoesNotExpire   => this.HasFlag(AccountFlags.PasswordDoesNotExpire);
+        public bool AutoLocked              => this.HasFlag(AccountFlags.AutoLocked);
+
+        // old way using builtin Enum.HasFlags() --> Too slow!
+        //public bool AccountDisabled { 
+        //    get {
+        //        return AccountFlagsEnum.HasFlag(AccountFlags.AccountDisabled);
+        //    }
+        //}
+
+        private bool HasFlag(AccountFlags flag)
+        {
+            return ((AccountFlagsEnum & flag) == flag);
         }
-        // and so on using the Enum.HasFlag method for each AccountFlags flag
-        // before I type this all out I just want to see if this approach even works
     }
 }

--- a/RegistryPlugin.SAM/UserOut.cs
+++ b/RegistryPlugin.SAM/UserOut.cs
@@ -8,7 +8,7 @@ namespace RegistryPlugin.SAM
             DateTimeOffset? lastPwChange, DateTimeOffset? lastIncorrectLogin, DateTimeOffset? expiresOn,
             string username,
             string fullName, string comment, string userComment, string homeDir, DateTimeOffset createdOn,
-            string groups, string pwHint, bool passwordPolicyRequired)
+            string groups, string pwHint, AccountFlags parsedAccountFlags)
         {
             UserId = userId;
             InvalidLoginCount = invalidLoginCount;
@@ -25,7 +25,7 @@ namespace RegistryPlugin.SAM
             CreatedOn = createdOn.UtcDateTime;
             Groups = groups;
             PasswordHint = pwHint;
-            PasswordPolicyRequired = passwordPolicyRequired;
+            AccountFlagsEnum = parsedAccountFlags;
         }
 
         public int UserId { get; }
@@ -51,6 +51,13 @@ namespace RegistryPlugin.SAM
         public string Comment { get; }
         public string UserComment { get; }
         public string HomeDirectory { get; }
-        public bool PasswordPolicyRequired { get; }
+        public bool AccountDisabled { 
+            get {
+                return AccountFlagsEnum.HasFlag(AccountFlags.AccountDisabled);
+            }
+            private set;  // correct if this is not good C# syntax
+        }
+        // and so on using the Enum.HasFlag method for each AccountFlags flag
+        // before I type this all out I just want to see if this approach even works
     }
 }

--- a/RegistryPlugin.SAM/UserOut.cs
+++ b/RegistryPlugin.SAM/UserOut.cs
@@ -8,7 +8,7 @@ namespace RegistryPlugin.SAM
             DateTimeOffset? lastPwChange, DateTimeOffset? lastIncorrectLogin, DateTimeOffset? expiresOn,
             string username,
             string fullName, string comment, string userComment, string homeDir, DateTimeOffset createdOn,
-            string groups, string pwHint)
+            string groups, string pwHint, bool passwordPolicyRequired)
         {
             UserId = userId;
             InvalidLoginCount = invalidLoginCount;
@@ -25,6 +25,7 @@ namespace RegistryPlugin.SAM
             CreatedOn = createdOn.UtcDateTime;
             Groups = groups;
             PasswordHint = pwHint;
+            PasswordPolicyRequired = passwordPolicyRequired;
         }
 
         public int UserId { get; }
@@ -50,5 +51,6 @@ namespace RegistryPlugin.SAM
         public string Comment { get; }
         public string UserComment { get; }
         public string HomeDirectory { get; }
+        public bool PasswordPolicyRequired { get; }
     }
 }


### PR DESCRIPTION
This proposed pull request parses additional SAM account flags for Windows local accounts. The primary source for these flags that I used was Harlan Carvey's RegRipper `samparse.pl` plugin code, specifically [the `acb_flags` beginning at line 52](https://github.com/keydet89/RegRipper2.8/blob/master/plugins/samparse.pl#L52). As discussed, I also updated the `LongDescription` of the `UserAccounts` class in the `RegistryPlugin.SAM` namespace to include a link to [Harlan's July 11, 2009 blog post](https://windowsir.blogspot.com/2009/07/user-account-analysis.html) which clarifies that the `PasswordNotRequired` flag does *not* mean that the user account doesn't have a password.