### PR TITLE
Update UserAccounts.cs

### DIFF
--- a/RegistryPlugin.SAM/UserAccounts.cs
+++ b/RegistryPlugin.SAM/UserAccounts.cs
@@ -172,9 +172,9 @@ namespace RegistryPlugin.SAM
                             lastIncorrectPwTime = tempTime.ToUniversalTime();
                         }
 
-                        if (fVal.ValueDataRaw.Length >= 0x56)
+                        if (fVal.ValueDataRaw.Length >= 0x38)
                         {
-                            parsedAccountFlags = (AccountFlags)BitConverter.ToInt16(fVal.ValueDataRaw, 0x56);
+                            parsedAccountFlags = (AccountFlags)BitConverter.ToInt16(fVal.ValueDataRaw, 0x38);
                         }
                         
                     }


### PR DESCRIPTION
In order to return values that show (for example) whether an account is disabled, or if the account requires a password, it needs to point to 0x38 (56) and not to 0x56. 

Source: https://pigstye.net/forensics/password.html