### PR TITLE
Recmd plugin for parsing TrustedDocuments key

### DIFF
--- a/RegistryPlugin.TrustedDocuments/Properties/AssemblyInfo.cs
+++ b/RegistryPlugin.TrustedDocuments/Properties/AssemblyInfo.cs
@@ -1,0 +1,35 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("RegistryPlugin.TrustedDocuments")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("RegistryPlugin.TrustedDocuments")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("5d95bf82-c1ba-4a41-862f-ac693fe3b334")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/RegistryPlugin.TrustedDocuments/RegistryPlugin.TrustedDocuments.csproj
+++ b/RegistryPlugin.TrustedDocuments/RegistryPlugin.TrustedDocuments.csproj
@@ -1,0 +1,61 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{5D95BF82-C1BA-4A41-862F-AC693FE3B334}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>RegistryPlugin.TrustedDocuments</RootNamespace>
+    <AssemblyName>RegistryPlugin.TrustedDocuments</AssemblyName>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="TrustedDocuments.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ValuesOut.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="RegistryPluginBase">
+      <Version>1.1.0</Version>
+    </PackageReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/RegistryPlugin.TrustedDocuments/TrustedDocuments.cs
+++ b/RegistryPlugin.TrustedDocuments/TrustedDocuments.cs
@@ -48,7 +48,7 @@ namespace RegistryPlugin.TrustedDocuments
         public string PluginName => "TrustedDocuments";
 
         public string ShortDescription =>
-            "Extracts names of Office documents where the user may have clicked on \"Enable Editing\" or \"Enable Macro or Enable Content\"";
+            "Extracts names of Office documents where the user may have clicked on \"Enable Editing\" or \"Enable Macro or Enable Content\"";;
 
         public string LongDescription => ShortDescription;
 
@@ -74,7 +74,7 @@ namespace RegistryPlugin.TrustedDocuments
                     var type = bin.Substring(bin.Length - 8);
                     string EventType;
                     byte[] dateval = StringToByteArray(hexDate);
-                    DateTime tstamp = ConvertWindowsDate(dateval);
+                    DateTimeOffset tstamp = ConvertWindowsDate(dateval);
                     if (type == "01000000")
                     {
                         EventType = "Enable Editing";
@@ -89,7 +89,7 @@ namespace RegistryPlugin.TrustedDocuments
                     }
                     // to read the username of the current NTUSER.DAT hive, go up a few levels and list the value Software\Microsoft\Internet Explorer\Suggested Sites\LocalLogFolder
                     var internetExplorerKey = key.Parent.Parent.Parent.Parent.Parent.Parent.SubKeys.SingleOrDefault(t => t.KeyName == "Internet Explorer");
-                    string username="";
+                    string username = "";
                     foreach (var registryKey in internetExplorerKey.SubKeys)
                     {
                         var suggestedSitesKey = internetExplorerKey.SubKeys.SingleOrDefault(t => t.KeyName == "Suggested Sites");
@@ -102,7 +102,7 @@ namespace RegistryPlugin.TrustedDocuments
                             }
                         }
                     }
-                    var v = new ValuesOut(EventType, tstamp.ToUniversalTime().ToString("yyyy-MM-dd HH:mm:ss.fffffff"), fName, username);
+                    var v = new ValuesOut(EventType, tstamp, fName, username);
                     v.BatchKeyPath = key.KeyPath;
                     v.BatchValueName = keyValue.ValueName;
                     _values.Add(v);
@@ -126,10 +126,10 @@ namespace RegistryPlugin.TrustedDocuments
                              .Select(x => Convert.ToByte(hex.Substring(x, 2), 16))
                              .ToArray();
         }
-        public static DateTime ConvertWindowsDate(byte[] bytes)
+        public static DateTimeOffset ConvertWindowsDate(byte[] bytes)
         {
             if (bytes.Length != 8) throw new ArgumentException();
-            return DateTime.FromFileTimeUtc(BitConverter.ToInt64(bytes, 0));
+            return DateTime.SpecifyKind((DateTime.FromFileTimeUtc(BitConverter.ToInt64(bytes, 0))),DateTimeKind.Utc);
         }
 
         public IBindingList Values => _values;

--- a/RegistryPlugin.TrustedDocuments/TrustedDocuments.cs
+++ b/RegistryPlugin.TrustedDocuments/TrustedDocuments.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using Registry.Abstractions;
+using RegistryPluginBase.Classes;
+using RegistryPluginBase.Interfaces;
+using System.Globalization;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace RegistryPlugin.TrustedDocuments
+{
+    public class TrustedDocuments : IRegistryPluginGrid
+    {
+        private readonly BindingList<ValuesOut> _values;
+
+        public TrustedDocuments()
+        {
+            _values = new BindingList<ValuesOut>();
+
+            Errors = new List<string>();
+        }
+
+        public string InternalGuid => "5866960d-0bf7-4a73-8443-931caeda30c3";
+
+        public List<string> KeyPaths => new List<string>(new[]
+        {
+            @"Software\Microsoft\Office\15.0\Word\Security\Trusted Documents\TrustRecords",
+            @"Software\Microsoft\Office\15.0\Excel\Security\Trusted Documents\TrustRecords",
+            @"Software\Microsoft\Office\15.0\PowerPoint\Security\Trusted Documents\TrustRecords",
+            @"Software\Microsoft\Office\15.0\Access\Security\Trusted Documents\TrustRecords",
+            @"Software\Microsoft\Office\15.0\OneNote\Security\Trusted Documents\TrustRecords",
+            @"Software\Microsoft\Office\16.0\Word\Security\Trusted Documents\TrustRecords",
+            @"Software\Microsoft\Office\16.0\Excel\Security\Trusted Documents\TrustRecords",
+            @"Software\Microsoft\Office\16.0\PowerPoint\Security\Trusted Documents\TrustRecords",
+            @"Software\Microsoft\Office\16.0\Access\Security\Trusted Documents\TrustRecords",
+            @"Software\Microsoft\Office\16.0\OneNote\Security\Trusted Documents\TrustRecords"
+        });
+
+        public string ValueName => null;
+        public string AlertMessage { get; private set; }
+        public RegistryPluginType.PluginType PluginType => RegistryPluginType.PluginType.Grid;
+        public string Author => "Partha Alwar";
+        public string Email => "parthaalwar@gmail.com";
+        public string Phone => "000-000-0000";
+        public string PluginName => "TrustedDocuments";
+
+        public string ShortDescription =>
+            "Extracts names of Office documents where the user may have clicked on \"Enable Editing\" or \"Enable Macro or Enable Content\"";
+
+        public string LongDescription => ShortDescription;
+
+        public double Version => 0.1;
+        public List<string> Errors { get; }
+
+
+        public void ProcessValues(RegistryKey key)
+        {
+            _values.Clear();
+            Errors.Clear();
+
+            try
+            {
+                foreach (var keyValue in key.Values)
+                {
+                    //value data contains binary data that provides the timestamp as well as information on if "Enable Macro" or "Enable Content" was clicked by the user
+                    var valData = keyValue.ValueData.ToString();
+                    //value name contains the full path of the document
+                    var fName = keyValue.ValueName;
+                    var bin = valData.ToString().Replace("-", "");
+                    var hexDate = bin.Substring(0, 16);
+                    var type = bin.Substring(bin.Length - 8);
+                    string EventType;
+                    byte[] dateval = StringToByteArray(hexDate);
+                    DateTime tstamp = ConvertWindowsDate(dateval);
+                    if (type == "01000000")
+                    {
+                        EventType = "Enable Editing";
+                    }
+                    else if (type == "FFFFFF7F")
+                    {
+                        EventType = "Enable Content/Macros";
+                    }
+                    else
+                    {
+                        EventType = "Unknown value";
+                    }
+                    // to read the username of the current NTUSER.DAT hive, go up a few levels and list the value Software\Microsoft\Internet Explorer\Suggested Sites\LocalLogFolder
+                    var internetExplorerKey = key.Parent.Parent.Parent.Parent.Parent.Parent.SubKeys.SingleOrDefault(t => t.KeyName == "Internet Explorer");
+                    string username="";
+                    foreach (var registryKey in internetExplorerKey.SubKeys)
+                    {
+                        var suggestedSitesKey = internetExplorerKey.SubKeys.SingleOrDefault(t => t.KeyName == "Suggested Sites");
+                        foreach (var value in suggestedSitesKey.Values)
+                        {
+                            if (value.ValueName == "LogFileFolder")
+                            {
+                                username = value.ValueData.Split('\\')[2].ToString();
+                                break;
+                            }
+                        }
+                    }
+                    var v = new ValuesOut(EventType, tstamp.ToUniversalTime().ToString("yyyy-MM-dd HH:mm:ss.fffffff"), fName, username);
+                    v.BatchKeyPath = key.KeyPath;
+                    v.BatchValueName = keyValue.ValueName;
+                    _values.Add(v);
+                }
+            }
+            catch (Exception ex)
+            {
+                Errors.Add($"Error processing Trusted Documents key: {ex.Message}");
+            }
+
+            if (Errors.Count > 0)
+            {
+                AlertMessage = "Errors detected. See Errors information in lower right corner of plugin window";
+            }
+        }
+
+        public static byte[] StringToByteArray(string hex)
+        {
+            return Enumerable.Range(0, hex.Length)
+                             .Where(x => x % 2 == 0)
+                             .Select(x => Convert.ToByte(hex.Substring(x, 2), 16))
+                             .ToArray();
+        }
+        public static DateTime ConvertWindowsDate(byte[] bytes)
+        {
+            if (bytes.Length != 8) throw new ArgumentException();
+            return DateTime.FromFileTimeUtc(BitConverter.ToInt64(bytes, 0));
+        }
+
+        public IBindingList Values => _values;
+    }
+}

--- a/RegistryPlugin.TrustedDocuments/ValuesOut.cs
+++ b/RegistryPlugin.TrustedDocuments/ValuesOut.cs
@@ -5,7 +5,7 @@ namespace RegistryPlugin.TrustedDocuments
 {
     public class ValuesOut:IValueOut
     {
-        public ValuesOut(string valueName, string tstamp, string fileName,string username)
+        public ValuesOut(string valueName, DateTimeOffset tstamp, string fileName,string username)
         {
             EventType = valueName;
             Timestamp = tstamp;
@@ -14,7 +14,7 @@ namespace RegistryPlugin.TrustedDocuments
         }
 
         public string EventType { get; }
-        public string Timestamp { get; }
+        public DateTimeOffset Timestamp { get; }
         public string FileName { get; }
         public string Username { get; }
         public string BatchKeyPath { get; set; }

--- a/RegistryPlugin.TrustedDocuments/ValuesOut.cs
+++ b/RegistryPlugin.TrustedDocuments/ValuesOut.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using RegistryPluginBase.Interfaces;
+
+namespace RegistryPlugin.TrustedDocuments
+{
+    public class ValuesOut:IValueOut
+    {
+        public ValuesOut(string valueName, string tstamp, string fileName,string username)
+        {
+            EventType = valueName;
+            Timestamp = tstamp;
+            FileName = fileName;
+            Username = username;
+        }
+
+        public string EventType { get; }
+        public string Timestamp { get; }
+        public string FileName { get; }
+        public string Username { get; }
+        public string BatchKeyPath { get; set; }
+        public string BatchValueName { get; set; }
+        public string BatchValueData1 => $"File name: {FileName}";
+        public string BatchValueData2 => $"File Opened: {Timestamp})";
+        public string BatchValueData3  => $"Event Type: {EventType})";
+    }
+}


### PR DESCRIPTION
The TrustedDocument key contains  names of Office documents where the user may have clicked on \"Enable Editing\" or \"Enable Macro or Enable Content\" along with their timestamp. This key can be very helpful in investigations involving malicious documents. 