### PR TITLE
ProfileList Plugin: split up ValueData data

### DIFF
--- a/RegistryPlugin.ProfileList/ValuesOut.cs
+++ b/RegistryPlugin.ProfileList/ValuesOut.cs
@@ -18,8 +18,8 @@ namespace RegistryPlugin.ProfileList
         public string ProfileImagePath { get; }
         public string BatchKeyPath { get; set; }
         public string BatchValueName { get; set; }
-        public string BatchValueData1 => $"KeyName: {KeyName} ProfileImagePath: {ProfileImagePath}";
+        public string BatchValueData1 => $"KeyName: {KeyName}";
         public string BatchValueData2 => $"Timestamp: {Timestamp?.ToUniversalTime():yyyy-MM-dd HH:mm:ss.fffffff}";
-        public string BatchValueData3 => string.Empty;
+        public string BatchValueData3 => $"ProfileImagePath: {ProfileImagePath}";
     }
 }


### PR DESCRIPTION
Previously, 2 values existed within ValueData and ValueData3 was empty. I moved the ProfileImagePath to ValueData3 so not so much data is being crammed into ValueData. 