### PR TITLE
New plugin to parse Adobe trust manager

### DIFF
--- a/RegistryPlugin.Adobe.TrustManager-Websites/AdobeTrustManager.cs
+++ b/RegistryPlugin.Adobe.TrustManager-Websites/AdobeTrustManager.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using Registry.Abstractions;
+using RegistryPluginBase.Classes;
+using RegistryPluginBase.Interfaces;
+
+namespace RegistryPlugin.Adobe.TrustManager_Websites
+{
+public class AdobeTrustManager : IRegistryPluginGrid
+    {
+        private readonly BindingList<ValuesOut> _values;
+
+        public AdobeTrustManager()
+        {
+            _values = new BindingList<ValuesOut>();
+
+            Errors = new List<string>();
+        }
+
+        public string InternalGuid => "91d835da-fb76-4b34-8732-22fabcc5ebbb";
+
+        public List<string> KeyPaths => new List<string>(new[]
+        {
+            @"Software\Adobe"
+        });
+
+        public string ValueName => null;
+        public string AlertMessage { get; private set; }
+        public RegistryPluginType.PluginType PluginType => RegistryPluginType.PluginType.Grid;
+        public string Author => "Mahmoud Soheem";
+        public string Email => "mahmood_soheem@yahoo.com";
+        public string Phone => "+201069641596";
+        public string PluginName => "Adobe User Accessed Websites";
+
+        public string ShortDescription =>
+            "Decodes Adobe Trust Manager Websites list";
+
+        public string LongDescription =>
+            "Parses Adobe trust manager websites accessed, and User Choice (Allowed or Blocked) ";
+
+        public double Version => 0.5;
+        public List<string> Errors { get; }
+
+        public void ProcessValues(RegistryKey key)
+        {
+            _values.Clear();
+            Errors.Clear();
+
+            try
+            {
+
+                foreach (var productKey in key.SubKeys)
+                {
+                    foreach (var versionKey in productKey.SubKeys)
+                    {
+                      
+                        var trustManager = versionKey.SubKeys.SingleOrDefault(t => t.KeyName == "TrustManager");
+
+                        var cDefaultLaunchURLPerms = trustManager?.SubKeys.SingleOrDefault(t => t.KeyName == "cDefaultLaunchURLPerms");
+
+                        if (cDefaultLaunchURLPerms == null)
+                        {
+                            continue;
+                        }
+                        var tHostPerms = cDefaultLaunchURLPerms.Values.SingleOrDefault(t => t.ValueName == "tHostPerms")?.ValueData;
+                        var websites = tHostPerms.Split('|');
+                        foreach (var website in websites)
+                        {
+                            if (website.Contains("version"))
+                            {
+                                continue;
+                            }
+                            var vWebsite = new ValuesOut(website.Substring(0, website.Length - 2), website[website.Length - 1]);
+                            vWebsite.BatchKeyPath = cDefaultLaunchURLPerms.KeyPath;
+                            vWebsite.BatchValueName = cDefaultLaunchURLPerms.KeyName;
+
+                            _values.Add(vWebsite);
+                        }
+                     
+                    }
+                }  
+                
+            }
+            catch (Exception ex)
+            {
+                Errors.Add($"Error processing Adobe products: {ex.Message}");
+            }
+
+            if (Errors.Count > 0)
+            {
+                AlertMessage = "Errors detected. See Errors information in lower right corner of plugin window";
+            }
+        }
+
+        
+
+        public IBindingList Values => _values;
+
+        private static string DecodeHexToAscii(string hex)
+        {
+            var sb = new StringBuilder();
+
+            for (var i = 0; i < hex.Length - 1; i += 2)
+            {
+                var chunk = hex.Substring(i, 2);
+
+                sb.Append(Convert.ToChar(Convert.ToUInt32(chunk, 16)).ToString());
+            }
+
+            return sb.ToString();
+        }
+    }
+}

--- a/RegistryPlugin.Adobe.TrustManager-Websites/Properties/AssemblyInfo.cs
+++ b/RegistryPlugin.Adobe.TrustManager-Websites/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("RegistryPlugin.Adobe.TrustManager_Websites")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("RegistryPlugin.Adobe.TrustManager_Websites")]
+[assembly: AssemblyCopyright("Copyright ©  2024")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("dcf8bccc-4acd-4269-bcfb-7e54c0ab5ff3")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/RegistryPlugin.Adobe.TrustManager-Websites/RegistryPlugin.Adobe.TrustManger-Websites.csproj
+++ b/RegistryPlugin.Adobe.TrustManager-Websites/RegistryPlugin.Adobe.TrustManger-Websites.csproj
@@ -1,0 +1,11 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+  <PropertyGroup>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="RegistryPluginBase" Version="1.3.1.2" />
+  </ItemGroup>
+</Project>

--- a/RegistryPlugin.Adobe.TrustManager-Websites/ValuesOut.cs
+++ b/RegistryPlugin.Adobe.TrustManager-Websites/ValuesOut.cs
@@ -1,0 +1,31 @@
+﻿using RegistryPluginBase.Interfaces;
+
+namespace RegistryPlugin.Adobe.TrustManager_Websites
+{
+    public class ValuesOut:IValueOut
+    {
+        public ValuesOut(string website, char userChoice)
+        {
+            Website = website;
+            switch (userChoice)
+            {
+                case '2': UserChoice = "Allow"; break;
+                case '3': UserChoice = "Block"; break;
+                default: UserChoice = "Undefined"; break;
+            }
+            
+           
+        }
+
+
+        public string Website { get; }
+        public string UserChoice { get; }
+
+
+        public string BatchKeyPath { get; set; }
+        public string BatchValueName { get; set; }
+        public string BatchValueData1 => $"Website: {Website}";
+        public string BatchValueData2 => $"User Choice: {UserChoice}";
+        public string BatchValueData3 => string.Empty;
+    }
+}


### PR DESCRIPTION
This plugin parses Adobe products trust manager and provide list of all websites user accessed and user's action of allow or block.