### PR TITLE
Update FirewallRules.cs

### DIFF
--- a/RegistryPlugin.FirewallRules/FirewallRules.cs
+++ b/RegistryPlugin.FirewallRules/FirewallRules.cs
@@ -19,7 +19,9 @@ namespace RegistryPlugin.FirewallRules
         public string InternalGuid => "a2e377a8-9c38-49e3-871a-b6b7057b624a";
         public List<string> KeyPaths => new List<string>(new[]
         {
-            @"ControlSet00*\Services\SharedAccess\Parameters\FirewallPolicy\FirewallRules"
+            @"ControlSet00*\Services\SharedAccess\Parameters\FirewallPolicy\FirewallRules",
+            @"ControlSet00*\Services\SharedAccess\Parameters\FirewallPolicy\RestrictedServices\AppIso\FirewallRules",
+            @"ControlSet00*\Services\SharedAccess\Parameters\FirewallPolicy\Mdm\FirewallRules"
         });
 
         public string ValueName => null;


### PR DESCRIPTION
Add paths for MDM managed firewall rules and WindowStore app rules.

Intune managed firewall rules are stored under: `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\SharedAccess\Parameters\FirewallPolicy\Mdm\FirewallRules`
per [How to trace and troubleshoot the Intune Endpoint Security Firewall rule creation process
](https://techcommunity.microsoft.com/t5/intune-customer-success/how-to-trace-and-troubleshoot-the-intune-endpoint-security/ba-p/3261452)

And Windows are stored under: `HKLM:\SYSTEM\CurrentControlSet\Services\SharedAccess\Parameters\FirewallPolicy\RestrictedServices\AppIso\FirewallRules` 
per [Get-Netfirewallrule](https://learn.microsoft.com/en-us/powershell/module/netsecurity/get-netfirewallrule?view=windowsserver2022-ps) documentation.