### PR TITLE
Fix RecentDocs plugin error

### DIFF
--- a/RegistryPlugin.RecentDocs/RecentDocs.cs
+++ b/RegistryPlugin.RecentDocs/RecentDocs.cs
@@ -149,8 +149,12 @@ namespace RegistryPlugin.RecentDocs
                         index += lnkName.Length;
                     }
 
-                    while (chunks[0][index] != 4)
+                    while (index <= chunks[0].Length - 4)
                     {
+                        if (BitConverter.ToUInt32(chunks[0], index) == 0xbeef0004)
+                        {
+                            break;
+                        }
                         index += 1; //move until our signature
                     }
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/89e82f10-f32b-43c4-ab65-d4c1575029d2)

![image](https://github.com/user-attachments/assets/2b1892ae-a39e-40b2-8b0f-4a1c35a00a78)
There was a problem with the RecentDocs plugin, so I contributed to it.

![image](https://github.com/user-attachments/assets/439a7104-40db-4bc9-9b02-314e0de4f94a)
I temporarily modified it to output the sig value in the Lnk Name.
I checked whether the sig variable correctly held the value 0xbeef0004, but some data was stored as different values.

![image](https://github.com/user-attachments/assets/644924b3-aae6-4860-b848-3b1983ecad2c)

![image](https://github.com/user-attachments/assets/84c98aa9-4da1-4ab6-bbea-fcd52746263f)
When converting 2901788676 to hex, it becomes 0xacf5c804, and the issue arose due to inadequate code for signature detection.
The Korean Unicode data contained the value 04.

![image](https://github.com/user-attachments/assets/d7cdcf55-c36c-46f2-91d1-833d9e5a5efd)
The following is the code to resolve this issue.

![image](https://github.com/user-attachments/assets/6f5935fe-c94a-4692-8400-f03a0d46b349)
Now, no errors occur.
