### PR TITLE
Add path to the product plugin

### DIFF
--- a/RegistryPlugin.Products/Products.cs
+++ b/RegistryPlugin.Products/Products.cs
@@ -21,7 +21,8 @@ namespace RegistryPlugin.Products
 
         public List<string> KeyPaths => new List<string>(new[]
         {
-            @"Microsoft\Windows\CurrentVersion\Installer\UserData\*\Products"
+            @"Microsoft\Windows\CurrentVersion\Installer\UserData\*\Products",
+            @"Classes\Installer\Products"
         });
 
         public string ValueName => null;
@@ -57,34 +58,70 @@ namespace RegistryPlugin.Products
         {
             var l = new List<ValuesOut>();
 
-            foreach (var subKey in key.SubKeys)
+            if (key.KeyPath.Contains("Classes"))
             {
-                try
+                foreach (var subKey in key.SubKeys)
                 {
-                    var properties = subKey.SubKeys.SingleOrDefault(t => t.KeyName == "InstallProperties");
-                    if (properties == null)
-                        continue;
-
-                    var displayName = properties.Values.SingleOrDefault(t => t.ValueName == "DisplayName")?.ValueData;
-                    var packageName = properties.Values.SingleOrDefault(t => t.ValueName == "DisplayVersion")?.ValueData;
-                    var installDate = properties.Values.SingleOrDefault(t => t.ValueName == "InstallDate")?.ValueData;
-                    var publisher = properties.Values.SingleOrDefault(t => t.ValueName == "Publisher")?.ValueData;
-                    var language = properties.Values.SingleOrDefault(t => t.ValueName == "Language")?.ValueData;
-                    var installLocation = properties.Values.SingleOrDefault(t => t.ValueName == "InstallLocation")?.ValueData;
-                    var installSource = properties.Values.SingleOrDefault(t => t.ValueName == "InstallSource")?.ValueData;
-                    var comments = properties.Values.SingleOrDefault(t => t.ValueName == "Comments")?.ValueData;
-                    DateTimeOffset? ts = properties.LastWriteTime;
-
-                    var ff = new ValuesOut(displayName, packageName, installDate, publisher, language, installLocation, installSource, comments, ts)
+                    try
                     {
-                        BatchValueName = "Multiple",
-                        BatchKeyPath = subKey.KeyPath
-                    };
-                    l.Add(ff);
+                        var productName = subKey.Values.SingleOrDefault(t => t.ValueName == "ProductName")?.ValueData;
+                        var language = subKey.Values.SingleOrDefault(t => t.ValueName == "Language")?.ValueData;
+
+                        var sourceList = subKey.SubKeys.SingleOrDefault(t => t.KeyName == "SourceList");
+                        string packageName = null;
+                        string lastUsedSource = null;
+
+                        if (sourceList != null)
+                        {
+                            packageName = sourceList.Values.SingleOrDefault(t => t.ValueName == "PackageName")?.ValueData;
+                            lastUsedSource = sourceList.Values.SingleOrDefault(t => t.ValueName == "LastUsedSource")?.ValueData;
+                        }
+                        DateTimeOffset? ts = subKey.LastWriteTime;
+
+                        var ff = new ValuesOut(productName, packageName, null, null, language, null, lastUsedSource, null, ts)
+                        {
+                            BatchValueName = "Multiple",
+                            BatchKeyPath = subKey.KeyPath
+                        };
+                        l.Add(ff);
+                    }
+                    catch (Exception ex)
+                    {
+                        Errors.Add($"Error processing Products key: {ex.Message}");
+                    }
                 }
-                catch (Exception ex)
+            }
+            else
+            {
+                foreach (var subKey in key.SubKeys)
                 {
-                    Errors.Add($"Error processing Products key: {ex.Message}");
+                    try
+                    {
+                        var properties = subKey.SubKeys.SingleOrDefault(t => t.KeyName == "InstallProperties");
+                        if (properties == null)
+                            continue;
+
+                        var displayName = properties.Values.SingleOrDefault(t => t.ValueName == "DisplayName")?.ValueData;
+                        var packageName = properties.Values.SingleOrDefault(t => t.ValueName == "DisplayVersion")?.ValueData;
+                        var installDate = properties.Values.SingleOrDefault(t => t.ValueName == "InstallDate")?.ValueData;
+                        var publisher = properties.Values.SingleOrDefault(t => t.ValueName == "Publisher")?.ValueData;
+                        var language = properties.Values.SingleOrDefault(t => t.ValueName == "Language")?.ValueData;
+                        var installLocation = properties.Values.SingleOrDefault(t => t.ValueName == "InstallLocation")?.ValueData;
+                        var installSource = properties.Values.SingleOrDefault(t => t.ValueName == "InstallSource")?.ValueData;
+                        var comments = properties.Values.SingleOrDefault(t => t.ValueName == "Comments")?.ValueData;
+                        DateTimeOffset? ts = properties.LastWriteTime;
+
+                        var ff = new ValuesOut(displayName, packageName, installDate, publisher, language, installLocation, installSource, comments, ts)
+                        {
+                            BatchValueName = "Multiple",
+                            BatchKeyPath = subKey.KeyPath
+                        };
+                        l.Add(ff);
+                    }
+                    catch (Exception ex)
+                    {
+                        Errors.Add($"Error processing Products key: {ex.Message}");
+                    }
                 }
             }
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/5bef5f3c-5c8b-4d41-9553-e20ed563a43c)
There is another path with the same key name, products. (`Classes\Installer\Products`)
However, data names inside are different, I placed them accordingly.

![image](https://github.com/user-attachments/assets/9cc3fcc7-4e60-4723-b144-de3bbea6d98f)
`Classes\Installer\Products`
![image](https://github.com/user-attachments/assets/37a7e752-7a9f-4bf0-a261-2c5adb88ad3b)
`Microsoft\Windows\CurrentVersion\Installer\UserData\*\Products`