### PR TITLE
Fix unicode issue in OpenSavePidlMRU Plugin

### DIFF
--- a/RegistryPlugin.OpenSavePidlMRU/OpenSavePidlMRU.cs
+++ b/RegistryPlugin.OpenSavePidlMRU/OpenSavePidlMRU.cs
@@ -164,11 +164,11 @@ namespace RegistryPlugin.OpenSavePidlMRU
                                     case 0xb1:
                                     case 0x31:
                                     case 0x35:
-                                    case 0x36:
                                         bag = new ShellBag0X31(bytese);
 
                                         break;
-                                    case 0x32:
+                                    case 0x32: // ascii
+                                    case 0x36: // unicode
                                         bag = new ShellBag0X32(bytese);
 
                                         break;

--- a/RegistryPlugin.OpenSavePidlMRU/ShellItems/ShellBag0x32.cs
+++ b/RegistryPlugin.OpenSavePidlMRU/ShellItems/ShellBag0x32.cs
@@ -62,9 +62,19 @@ namespace RegistryPlugin.OpenSavePidlMRU.ShellItems
 
             var len = 0;
 
-            while (rawBytes[index + len] != 0x0)
+            if (rawBytes[2] == 0x32) // ascii
             {
-                len += 1;
+                while (rawBytes[index + len] != 0x0)
+                {
+                    len += 1;
+                }
+            }
+            else if (rawBytes[2] == 0x36) // unicode
+            {
+                while (!(rawBytes[index + len] == 0x0 && rawBytes[index + len + 1] == 0x0))
+                {
+                    len += 2;
+                }
             }
 
             tempBytes = new byte[len];

--- a/RegistryPlugin.OpenSavePidlMRU/ShellItems/ShellBag0x32.cs
+++ b/RegistryPlugin.OpenSavePidlMRU/ShellItems/ShellBag0x32.cs
@@ -82,7 +82,15 @@ namespace RegistryPlugin.OpenSavePidlMRU.ShellItems
 
             index += len;
 
-            var shortName = CodePagesEncodingProvider.Instance.GetEncoding(1252).GetString(tempBytes);
+            String shortName = string.Empty;
+            if (rawBytes[2] == 0x32) // ascii
+            {
+                shortName = CodePagesEncodingProvider.Instance.GetEncoding(1252).GetString(tempBytes);
+            }
+            else if (rawBytes[2] == 0x36) // unicode
+            {
+                shortName = Encoding.Unicode.GetString(tempBytes);
+            }
 
             ShortName = shortName;
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/acc1d868-3d6d-4566-b3d3-4c7333303f23)
The korean text appears broken, and an error message is also shown.

![image](https://github.com/user-attachments/assets/def6cf52-f3a3-4514-867a-496e9234dfe7)
https://github.com/EricZimmerman/RegistryPlugins/blob/de7e240f52145af0b7dc7325a852e11b5ac14ea4/RegistryPlugin.OpenSavePidlMRU/OpenSavePidlMRU.cs#L164-L174

On my PC, 0x36 represents a unicode file name. 
However, in the code, 0x36 is being handled using ShellBag0x31(Directory).
Maybe 0x35 = unicode directory, 0x36 = unicode file name.

![image](https://github.com/user-attachments/assets/26c13db7-f3a1-4635-9c0a-a6cc4aa097f7)
No errors now :)
